### PR TITLE
fix run names

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ runs:
         python-version: "3"
     - if: inputs.summary-table-properties != ''
       shell: bash
-      run: python ./_pytestresultsdiff/scripts/generate_markdown_table.py ${{ steps.filename.outputs.filename }} ${{ inputs.summary-table-properties }} ${{ inputs.summary-table-run-names }} >> $GITHUB_STEP_SUMMARY
+      run: python ./_pytestresultsdiff/scripts/generate_markdown_table.py --run-names=${{ inputs.summary-table-run-names }} ${{ steps.filename.outputs.filename }} ${{ inputs.summary-table-properties }} >> $GITHUB_STEP_SUMMARY
     - id: output
       shell: bash
       run: echo output=$(cat ${{ steps.filename.outputs.filename }}) >> $GITHUB_OUTPUT


### PR DESCRIPTION
fix issue where `run-names` was not correctly entered into the arguments 😅 

before:
[<img width="769" alt="image" src="https://github.com/user-attachments/assets/51ad7235-267b-400f-a758-5ab73faf9a1b" />](https://github.com/zacharyburnett/pytestresultsdiff/actions/runs/14448071139/attempts/1#summary-40513535514)

after:
[<img width="673" alt="image" src="https://github.com/user-attachments/assets/9a32d90e-b09c-4836-97fd-a2bbfd59be5f" />](https://github.com/zacharyburnett/pytestresultsdiff/actions/runs/14495645114/attempts/1#summary-40662565818)